### PR TITLE
OMT-208 hotfix to delete dedrem on review submit

### DIFF
--- a/claim/test_validations.py
+++ b/claim/test_validations.py
@@ -1,6 +1,7 @@
-from claim.models import Claim, ClaimDedRem
+from claim.gql_mutations import set_claims_status, delete_claim_dedrems
+from claim.models import Claim, ClaimDedRem, ClaimItem
 from claim.test_helpers import create_test_claim, create_test_claimservice, create_test_claimitem, \
-    mark_test_claim_as_processed
+    mark_test_claim_as_processed, delete_claim_with_itemsvc_dedrem_and_history
 from claim.validations import get_claim_category, validate_claim, validate_assign_prod_to_claimitems_and_services, \
     process_dedrem, REJECTION_REASON_WAITING_PERIOD_FAIL
 from django.test import TestCase
@@ -853,6 +854,81 @@ class ValidationTest(TestCase):
         service1.delete()
         item1.delete()
         claim1.delete()
+        policy.insuree_policies.first().delete()
+        policy.delete()
+        product_item.delete()
+        product_service.delete()
+        pricelist_detail1.delete()
+        pricelist_detail2.delete()
+        service.delete()
+        item.delete()
+        product.delete()
+
+    def test_review_reject_delete_dedrem(self):
+        """
+        This test creates a claim, submits it so that it gets dedrem entries,
+        then submits a review rejecting part of it, then process the claim.
+        It should not be processed (which was ok) but the dedrem should be deleted.
+        """
+        # Given
+        insuree = create_test_insuree()
+        self.assertIsNotNone(insuree)
+        service = create_test_service("A", custom_props={"name": "test_review_reject_delete_dedrem"})
+        item = create_test_item("A", custom_props={"name": "test_review_reject_delete_dedrem"})
+
+        product = create_test_product("BCUL0001", custom_props={
+            "name": "Basic Cover Ultha deldedrem",
+            "lump_sum": 10_000,
+        })
+        product_service = create_test_product_service(product, service)
+        product_item = create_test_product_item(product, item)
+        policy = create_test_policy(product, insuree, link=True)
+        pricelist_detail1 = add_service_to_hf_pricelist(service)
+        pricelist_detail2 = add_item_to_hf_pricelist(item)
+
+        claim1 = create_test_claim({"insuree_id": insuree.id})
+        service1 = create_test_claimservice(
+            claim1, custom_props={"service_id": service.id})
+        item1 = create_test_claimitem(
+            claim1, "A", custom_props={"item_id": item.id})
+        errors = validate_claim(claim1, True)
+        errors += validate_assign_prod_to_claimitems_and_services(claim1)
+        errors += process_dedrem(claim1, -1, False)
+
+        self.assertEqual(len(errors), 0)
+        # Make sure that the dedrem was generated
+        dedrem = ClaimDedRem.objects.filter(claim=claim1).first()
+        self.assertIsNotNone(dedrem)
+        self.assertEquals(dedrem.rem_g, 1400)
+
+        # Review the claim and reject all of it
+        # A partial rejection would still trigger the process_dedrem and be fine
+        item1.qty_approved = 0
+        item1.status = ClaimItem.STATUS_REJECTED
+        item1.audit_user_id_review = -1
+        item1.justification = "Review comment item"
+        item1.save()
+
+        service1.qty_approved = 0
+        service1.status = ClaimItem.STATUS_REJECTED
+        service1.audit_user_id_review = -1
+        service1.justification = "Review comment svc"
+        service1.save()
+
+        delete_claim_dedrems([claim1.uuid])
+        set_claims_status([claim1.uuid], "review_status", Claim.FEEDBACK_DELIVERED)
+
+        # Then dedrem should have been deleted
+        dedrem = ClaimDedRem.objects.filter(claim=claim1).first()
+        self.assertIsNone(dedrem)
+
+        claim1.refresh_from_db()
+        item1.refresh_from_db()
+        service1.refresh_from_db()
+
+        # tearDown
+        # dedrem.delete() # already done if the test passed
+        delete_claim_with_itemsvc_dedrem_and_history(claim1)
         policy.insuree_policies.first().delete()
         policy.delete()
         product_item.delete()


### PR DESCRIPTION
Since the dedrem is now computed on submit, rejecting a claim on review makes it so that the claim is not further processed on "process claim" and therefore there are lingering dedrem that are out of date. This change will just remove it and let the process claim restore it if appropriate.

I added a helper for tests to make deleting the claims easier. I'll apply it to the rest of the tests on the main branch when appropriate.

I wrote this on a Django 3 branch, so please retest.