### PR TITLE
OMT-208 hotfix to compute dedrem on review submit

### DIFF
--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -7,7 +7,7 @@ import graphene
 from .apps import ClaimConfig
 from claim.validations import validate_claim, get_claim_category, validate_assign_prod_to_claimitems_and_services, \
     process_dedrem, approved_amount
-from core import prefix_filterset, ExtendedConnection, filter_validity, Q, assert_string_length
+from core import prefix_filterset, ExtendedConnection, filter_validity, assert_string_length
 from core.schema import TinyInt, SmallInt, OpenIMISMutation, OrderedDjangoFilterConnectionField
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -17,7 +17,7 @@ from django.db.models.functions import Coalesce, Cast
 from django.utils.translation import gettext as _
 from graphene import InputObjectType
 from location.schema import UserDistrict
-from .models import Claim, Feedback, ClaimDetail, ClaimItem, ClaimService, ClaimAttachment
+from .models import Claim, Feedback, ClaimDetail, ClaimItem, ClaimService, ClaimAttachment, ClaimDedRem
 from product.models import ProductItemOrService
 
 logger = logging.getLogger(__name__)
@@ -612,6 +612,16 @@ def set_claims_status(uuids, field, status):
     return errors
 
 
+def update_claims_dedrems(uuids, user):
+    # We could do it in one query with filter(claim__uuid__in=uuids) but we'd loose the logging
+    errors = []
+    for uuid in uuids:
+        logger.debug(f"delivering review on {uuid}, reprocessing dedrem ({user})")
+        claim = Claim.objects.get(uuid=uuid)
+        errors += validate_and_process_dedrem_claim(claim, user, False)
+    return errors
+
+
 class SelectClaimsForFeedbackMutation(OpenIMISMutation):
     """
     Select one or several claims for feedback.
@@ -698,7 +708,7 @@ class DeliverClaimFeedbackMutation(OpenIMISMutation):
                 defaults=feedback
             )
             claim.feedback = f
-            claim.feedback_status = 8
+            claim.feedback_status = Claim.FEEDBACK_DELIVERED
             claim.feedback_available = True
             claim.save()
             return None
@@ -742,6 +752,7 @@ class BypassClaimsReviewMutation(OpenIMISMutation):
             raise PermissionDenied(_("unauthorized"))
         return set_claims_status(data['uuids'], 'review_status', 16)
 
+
 class DeliverClaimsReviewMutation(OpenIMISMutation):
     """
     Mark claim review as delivered for one or several claims
@@ -756,7 +767,12 @@ class DeliverClaimsReviewMutation(OpenIMISMutation):
     def async_mutate(cls, user, **data):
         if not user.has_perms(ClaimConfig.gql_mutation_deliver_claim_review_perms):
             raise PermissionDenied(_("unauthorized"))
-        return set_claims_status(data['uuids'], 'review_status', 8)
+        errors = set_claims_status(data['uuids'], 'review_status', Claim.REVIEW_DELIVERED)
+        # OMT-208 update the dedrem for the reviewed claims
+        errors += update_claims_dedrems(data["uuids"], user)
+
+        return errors
+
 
 class SkipClaimsReviewMutation(OpenIMISMutation):
     """
@@ -857,15 +873,8 @@ class ProcessClaimsMutation(OpenIMISMutation):
                 continue
             claim.save_history()
             logger.debug("ProcessClaimsMutation: validating claim %s", claim_uuid)
-            c_errors += validate_claim(claim, False)
-            logger.debug("ProcessClaimsMutation: claim %s validated, nb of errors: %s", claim_uuid, len(c_errors))
-            if len(c_errors) == 0:
-                c_errors = validate_assign_prod_to_claimitems_and_services(claim)
-                logger.debug("ProcessClaimsMutation: claim %s assigned, nb of errors: %s", claim_uuid, len(c_errors))
-                c_errors += process_dedrem(claim, user.id_for_audit, True)
-                logger.debug("ProcessClaimsMutation: claim %s processed for dedrem, nb of errors: %s", claim_uuid,
-                             len(errors))
-            c_errors += set_claim_processed_or_valuated(claim, c_errors, user)
+            c_errors += validate_and_process_dedrem_claim(claim, user, True)
+
             logger.debug("ProcessClaimsMutation: claim %s set processed or valuated", claim_uuid)
             if c_errors:
                 errors.append({
@@ -875,7 +884,7 @@ class ProcessClaimsMutation(OpenIMISMutation):
 
         if len(errors) == 1:
             errors = errors[0]['list']
-        logger.debug("ProcessClaimsMutation: claim %s done, errors: %s", claim_uuid, len(errors))
+        logger.debug("ProcessClaimsMutation: claims %s done, errors: %s", data["uuids"], len(errors))
         return errors
 
 
@@ -976,3 +985,22 @@ def set_claim_processed_or_valuated(claim, errors, user):
             'list': [{'message': _("claim.mutation.failed_to_change_status_of_claim") % {'code': claim.code},
                       'detail': claim.uuid}]
         }
+
+
+def validate_and_process_dedrem_claim(claim, user, is_process):
+    errors = validate_claim(claim, False)
+    logger.debug("ProcessClaimsMutation: claim %s validated, nb of errors: %s", claim.uuid, len(errors))
+    if len(errors) == 0:
+        errors = validate_assign_prod_to_claimitems_and_services(claim)
+        logger.debug("ProcessClaimsMutation: claim %s assigned, nb of errors: %s", claim.uuid, len(errors))
+        errors += process_dedrem(claim, user.id_for_audit, is_process)
+        logger.debug("ProcessClaimsMutation: claim %s processed for dedrem, nb of errors: %s", claim.uuid,
+                     len(errors))
+    else:
+        # OMT-208 the claim is invalid. If there is a dedrem, we need to clear it (caused by a review)
+        deleted_dedrems = ClaimDedRem.objects.filter(claim=claim).delete()
+        if deleted_dedrems:
+            logger.debug(f"Claim {claim.uuid} is invalid, we deleted its dedrem ({deleted_dedrems})")
+    if is_process:
+        errors += set_claim_processed_or_valuated(claim, errors, user)
+    return errors

--- a/claim/test_validations.py
+++ b/claim/test_validations.py
@@ -1,9 +1,9 @@
 from claim.gql_mutations import set_claims_status, update_claims_dedrems
-from claim.models import Claim, ClaimDedRem, ClaimItem
+from claim.models import Claim, ClaimDedRem, ClaimItem, ClaimDetail
 from claim.test_helpers import create_test_claim, create_test_claimservice, create_test_claimitem, \
     mark_test_claim_as_processed, delete_claim_with_itemsvc_dedrem_and_history
 from claim.validations import get_claim_category, validate_claim, validate_assign_prod_to_claimitems_and_services, \
-    process_dedrem, REJECTION_REASON_WAITING_PERIOD_FAIL
+    process_dedrem, REJECTION_REASON_WAITING_PERIOD_FAIL, REJECTION_REASON_INVALID_ITEM_OR_SERVICE
 from core.models import User
 from django.test import TestCase
 from insuree.models import Family, Insuree
@@ -865,7 +865,7 @@ class ValidationTest(TestCase):
         item.delete()
         product.delete()
 
-    def test_review_reject_delete_dedrem(self):
+    def test_review_reject_update_dedrem(self):
         """
         This test creates a claim, submits it so that it gets dedrem entries,
         then submits a review rejecting part of it, then process the claim.
@@ -929,6 +929,102 @@ class ValidationTest(TestCase):
         dedrem = ClaimDedRem.objects.filter(claim=claim1).first()
         self.assertIsNotNone(dedrem)
         self.assertEquals(dedrem.rem_g, 37 + 53)
+
+        # tearDown
+        # dedrem.delete() # already done if the test passed
+        delete_claim_with_itemsvc_dedrem_and_history(claim1)
+        policy.insuree_policies.first().delete()
+        policy.delete()
+        product_item.delete()
+        product_service.delete()
+        pricelist_detail1.delete()
+        pricelist_detail2.delete()
+        service.delete()
+        item.delete()
+        product.delete()
+
+
+    def test_review_reject_delete_dedrem(self):
+        """
+        This test creates a claim, submits it so that it gets dedrem entries,
+        then submits a review rejecting part of it, then process the claim.
+        It should not be processed (which was ok) but the dedrem should be deleted.
+        """
+        # Given
+        insuree = create_test_insuree()
+        self.assertIsNotNone(insuree)
+        service = create_test_service("A", custom_props={"name": "test_review_reject_delete_dedrem"})
+        item = create_test_item("A", custom_props={"name": "test_review_reject_delete_dedrem"})
+
+        product = create_test_product("BCUL0001", custom_props={
+            "name": "Basic Cover Ultha deldedrem",
+            "lump_sum": 10_000,
+        })
+        product_service = create_test_product_service(product, service)
+        product_item = create_test_product_item(product, item)
+        policy = create_test_policy(product, insuree, link=True)
+        pricelist_detail1 = add_service_to_hf_pricelist(service)
+        pricelist_detail2 = add_item_to_hf_pricelist(item)
+
+        claim1 = create_test_claim({"insuree_id": insuree.id})
+        service1 = create_test_claimservice(
+            claim1, custom_props={"service_id": service.id, "qty_provided": 2})
+        item1 = create_test_claimitem(
+            claim1, "A", custom_props={"item_id": item.id, "qty_provided": 3})
+        errors = validate_claim(claim1, True)
+        errors += validate_assign_prod_to_claimitems_and_services(claim1)
+        errors += process_dedrem(claim1, -1, False)
+
+        self.assertEqual(len(errors), 0)
+        # Make sure that the dedrem was generated
+        dedrem = ClaimDedRem.objects.filter(claim=claim1).first()
+        self.assertIsNotNone(dedrem)
+        self.assertEquals(dedrem.rem_g, 500)  # 100*2 + 100*3
+
+        # Review the claim and reject all of it
+        # A partial rejection would still trigger the process_dedrem and be fine
+        item1.qty_approved = 0
+        item1.price_approved = 0
+        item1.status = ClaimItem.STATUS_REJECTED
+        item1.rejection_reason = -1
+        item1.audit_user_id_review = -1
+        item1.justification = "Review comment item"
+        item1.save()
+
+        service1.qty_approved = 0
+        service1.price_approved = 0
+        service1.status = ClaimItem.STATUS_REJECTED
+        service1.rejection_reason = -1
+        service1.audit_user_id_review = -1
+        service1.justification = "Review comment svc"
+        service1.save()
+
+        claim1.refresh_from_db()
+        item1.refresh_from_db()
+        service1.refresh_from_db()
+
+        set_claims_status([claim1.uuid], "review_status", Claim.REVIEW_DELIVERED)
+        update_claims_dedrems([claim1.uuid], User.objects.first())
+
+        errors = validate_claim(claim1, True)
+        if len(errors) == 0:
+            errors += validate_assign_prod_to_claimitems_and_services(claim1)
+            errors += process_dedrem(claim1, -1, False)
+
+        # The claim should be globally rejected since the review rejected all items/svc
+        claim1.refresh_from_db()
+        item1.refresh_from_db()
+        service1.refresh_from_db()
+        self.assertEquals(claim1.status, Claim.STATUS_REJECTED)
+        self.assertEquals(claim1.rejection_reason, REJECTION_REASON_INVALID_ITEM_OR_SERVICE)
+        self.assertEquals(item1.status, ClaimDetail.STATUS_REJECTED)
+        self.assertEquals(item1.rejection_reason, -1)
+        self.assertEquals(service1.status, ClaimDetail.STATUS_REJECTED)
+        self.assertEquals(service1.rejection_reason, -1)
+
+        # Then dedrem should have been deleted
+        dedrem = ClaimDedRem.objects.filter(claim=claim1).first()
+        self.assertIsNone(dedrem)
 
         # tearDown
         # dedrem.delete() # already done if the test passed

--- a/claim/validations.py
+++ b/claim/validations.py
@@ -43,6 +43,7 @@ def validate_claim(claim, check_max):
     """
     Based on the legacy validation, this method returns standard codes along with details
     :param claim: claim to be verified
+    :param check_max: max amount to validate. Everything above will be rejected
     :return: (result_code, error_details)
     """
     logger.debug(f"Validating claim {claim.uuid}")
@@ -94,14 +95,18 @@ def validate_claim(claim, check_max):
                     'message': _("claim.validation.all_items_and_services_rejected") % {
                         'code': claim.code},
                     'detail': claim.uuid}]
+        claim.status = Claim.STATUS_REJECTED
+        claim.rejection_reason = REJECTION_REASON_INVALID_ITEM_OR_SERVICE
+        claim.save()
     logger.debug(f"Validation found {len(errors)} error(s)")
     return errors
 
 
 def validate_claimitems(claim):
     target_date = claim.date_from if claim.date_from else claim.date_to
-    for claimitem in claim.items.filter(validity_to__isnull=True):
-        claimitem.rejection_reason = None
+    for claimitem in claim.items\
+            .filter(validity_to__isnull=True)\
+            .filter(Q(rejection_reason=0) | Q(rejection_reason__isnull=True)):
         validate_claimitem_validity(claimitem)
         if not claimitem.rejection_reason:
             validate_claimitem_in_price_list(claim, claimitem)
@@ -131,8 +136,9 @@ def validate_claimservices(claim):
     target_date = claim.date_from if claim.date_from else claim.date_to
     base_category = get_claim_category(claim)
 
-    for claimservice in claim.services.all():
-        claimservice.rejection_reason = None
+    for claimservice in claim.services\
+            .filter(validity_to__isnull=True)\
+            .filter(Q(rejection_reason=0) | Q(rejection_reason__isnull=True)):
         validate_claimservice_validity(claimservice)
         if not claimservice.rejection_reason:
             validate_claimservice_in_price_list(claim, claimservice)


### PR DESCRIPTION
Since the dedrem is now computed on submit, delivering a review with adapted quantities didn't update the dedrem. We are now processing the dedrem again and deleting it if the updated claim is then invalid/rejected.

This was already review by Xavier in the previous PR but not on this one yet.