### PR TITLE
always historize items & services on claim change

### DIFF
--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -236,8 +236,8 @@ def process_child_relation(user, data_children,
     claimed = 0
     from core.utils import TimeUtils
     for data_elt in data_children:
-        claimed += data_elt['qty_provided'] * elt['price_asked']
-        elt_id = data_elt.pop('id') if 'id' in elt else None
+        claimed += data_elt['qty_provided'] * data_elt['price_asked']
+        elt_id = data_elt.pop('id') if 'id' in data_elt else None
         if elt_id:
             # elt has been historized along with claim historization
             elt = children.get(id=elt_id)

--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -247,8 +247,8 @@ def process_child_relation(user, data_children,
             elt.claim_id = claim_id
             elt.save()
         else:
-            elt['validity_from'] = TimeUtils.now()
-            elt['audit_user_id'] = user.id_for_audit
+            data_elt['validity_from'] = TimeUtils.now()
+            data_elt['audit_user_id'] = user.id_for_audit
             create_hook(claim_id, data_elt)
 
     return claimed

--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -242,10 +242,10 @@ def process_child_relation(user, data_children,
             # elt has been historized along with claim historization
             elt = children.get(id=elt_id)
             [setattr(elt, key, data_elt[key]) for key in data_elt]
-            new_elt.validity_from = TimeUtils.now()
-            new_elt.audit_user_id = user.id_for_audit
-            new_elt.claim_id = claim_id
-            new_elt.save()
+            elt.validity_from = TimeUtils.now()
+            elt.audit_user_id = user.id_for_audit
+            elt.claim_id = claim_id
+            elt.save()
         else:
             elt['validity_from'] = TimeUtils.now()
             elt['audit_user_id'] = user.id_for_audit


### PR DESCRIPTION
- ensure any claim update does historize all its items/services (even when not touched during the update)
- historize items/services via their save_history (to ensure the 'swap' id is applied: smallest id remains the live id)