### PR TITLE
OAI-36: Revert changes in get_queryset

### DIFF
--- a/claim/gql_queries.py
+++ b/claim/gql_queries.py
@@ -88,9 +88,7 @@ class ClaimGQLType(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        claim_ids = Claim.get_queryset(queryset, info).values('uuid').all()
-
-        return Claim.objects.filter(uuid__in=claim_ids)
+        return Claim.get_queryset(queryset, info)
 
 
 class ClaimAttachmentGQLType(DjangoObjectType):


### PR DESCRIPTION
Way of solving the issue with duplicate records caused errors during navigating to claim creation form.