### PR TITLE
Add generateclaims command

### DIFF
--- a/claim/management/commands/generateclaimadmins.py
+++ b/claim/management/commands/generateclaimadmins.py
@@ -1,0 +1,53 @@
+import random
+import string
+
+from claim.test_helpers import create_test_claim_admin
+from django.core.management.base import BaseCommand
+from faker import Faker
+
+
+class Command(BaseCommand):
+    help = "This command will generate test Claims Administrators. It is intended to simulate larger" \
+           "databases for performance testing. Some locations have almost 1000 of them."
+    insurees = None
+    services = None
+    items = None
+    claim_admins = None
+    hfs = None
+
+    def add_arguments(self, parser):
+        parser.add_argument("nb_admins", nargs=1, type=int)
+        parser.add_argument(
+            '--verbose',
+            action='store_true',
+            dest='verbose',
+            help='Be verbose about what it is doing',
+        )
+        parser.add_argument(
+            '--locale',
+            default="fr_FR",
+            help="Used to adapt the fake names generation to the locale, using Faker, by default fr_FR",
+        )
+
+    def handle(self, *args, **options):
+
+        nb_admins = options["nb_admins"][0]
+        verbose = options["verbose"]
+        fake = Faker(options["locale"])
+        for admin_num in range(1, nb_admins + 1):
+            hf = self.get_random_hf()
+            claim_admin = create_test_claim_admin({
+                "code": ''.join(random.choices(string.ascii_uppercase + string.digits, k=8)),
+                "last_name": fake.last_name(),
+                "other_names": fake.first_name(),
+                "email_id": fake.ascii_email(),
+                "phone": "+" + fake.msisdn(),
+                "health_facility_id": hf})
+            if verbose:
+                print(admin_num, "created claim admin", claim_admin, "for HF", hf, "with code", claim_admin.code)
+
+    def get_random_hf(self):
+        if not self.hfs:
+            from location.models import HealthFacility
+            self.hfs = HealthFacility.objects.filter(validity_to__isnull=True).values_list("pk", flat=True)
+        return random.choice(self.hfs)

--- a/claim/management/commands/generateclaims.py
+++ b/claim/management/commands/generateclaims.py
@@ -1,5 +1,7 @@
 import random
+import string
 
+from claim.models import ClaimAdmin
 from claim.test_helpers import create_test_claim, create_test_claimservice, create_test_claimitem
 from django.core.management.base import BaseCommand
 from insuree.models import Insuree
@@ -12,6 +14,8 @@ class Command(BaseCommand):
     insurees = None
     services = None
     items = None
+    claim_admins = None
+    hfs = None
 
     def add_arguments(self, parser):
         parser.add_argument("nb_claims", nargs=1, type=int)
@@ -31,9 +35,14 @@ class Command(BaseCommand):
         verbose = options["verbose"]
         for claim_num in range(1, nb_claims + 1):
             insuree = self.get_random_insuree()
-            claim = create_test_claim({"insuree_id": insuree})
+            claim_admin = self.get_random_claim_admin()
+            hf = self.get_random_hf()
+            claim = create_test_claim({"insuree_id": insuree,
+                                       "code": ''.join(random.choices(string.ascii_uppercase + string.digits, k=8)),
+                                       "admin_id": claim_admin,
+                                       "health_facility_id": hf})
             if verbose:
-                print(claim_num, "created claim", claim, "for insuree", insuree)
+                print(claim_num, "created claim", claim, "for insuree", insuree, "with code", claim.code)
             for svc_num in range(1, nb_services + 1):
                 service = self.get_random_service()
                 claim_service = create_test_claimservice(claim, custom_props={"service_id": service})
@@ -54,3 +63,14 @@ class Command(BaseCommand):
         if not self.services:
             self.services = Service.objects.filter(validity_to__isnull=True).values_list("pk", flat=True)
         return random.choice(self.services)
+
+    def get_random_claim_admin(self):
+        if not self.claim_admins:
+            self.claim_admins = ClaimAdmin.objects.filter(validity_to__isnull=True).values_list("pk", flat=True)
+        return random.choice(self.claim_admins)
+
+    def get_random_hf(self):
+        if not self.hfs:
+            from location.models import HealthFacility
+            self.hfs = HealthFacility.objects.filter(validity_to__isnull=True).values_list("pk", flat=True)
+        return random.choice(self.hfs)

--- a/claim/management/commands/generateclaims.py
+++ b/claim/management/commands/generateclaims.py
@@ -1,0 +1,56 @@
+import random
+
+from claim.test_helpers import create_test_claim, create_test_claimservice, create_test_claimitem
+from django.core.management.base import BaseCommand
+from insuree.models import Insuree
+from medical.models import Service
+
+
+class Command(BaseCommand):
+    help = "This command will generate test Claims with some optional parameters. It is intended to simulate larger" \
+           "databases for performance testing"
+    insurees = None
+    services = None
+    items = None
+
+    def add_arguments(self, parser):
+        parser.add_argument("nb_claims", nargs=1, type=int)
+        parser.add_argument("nb_services", nargs=1, type=int, help="number of services per claim, with 10% randomness")
+        parser.add_argument("nb_items", nargs=1, type=int, help="number of items per claim, with 10% randomness")
+        parser.add_argument(
+            '--verbose',
+            action='store_true',
+            dest='verbose',
+            help='Be verbose about what it is doing',
+        )
+
+    def handle(self, *args, **options):
+        nb_claims = options["nb_claims"][0]
+        nb_services = options["nb_services"][0]
+        nb_items = options["nb_items"][0]
+        verbose = options["verbose"]
+        for claim_num in range(1, nb_claims + 1):
+            insuree = self.get_random_insuree()
+            claim = create_test_claim({"insuree_id": insuree})
+            if verbose:
+                print(claim_num, "created claim", claim, "for insuree", insuree)
+            for svc_num in range(1, nb_services + 1):
+                service = self.get_random_service()
+                claim_service = create_test_claimservice(claim, custom_props={"service_id": service})
+                if verbose:
+                    print(claim_num, svc_num, "Created claim service", claim_service, "for service", service)
+            for item_num in range(1, nb_items + 1):
+                item = self.get_random_service()
+                claim_item = create_test_claimitem(claim, "D", custom_props={"item_id": item})
+                if verbose:
+                    print(claim_num, item_num, "Created claim service", claim_item, "for service", item)
+
+    def get_random_insuree(self):
+        if not self.insurees:
+            self.insurees = Insuree.objects.filter(validity_to__isnull=True).values_list("pk", flat=True)
+        return random.choice(self.insurees)
+
+    def get_random_service(self):
+        if not self.services:
+            self.services = Service.objects.filter(validity_to__isnull=True).values_list("pk", flat=True)
+        return random.choice(self.services)

--- a/claim/test_helpers.py
+++ b/claim/test_helpers.py
@@ -1,4 +1,4 @@
-from claim.models import Claim, ClaimService, ClaimItem, ClaimDedRem
+from claim.models import Claim, ClaimService, ClaimItem, ClaimDedRem, ClaimAdmin
 from claim.validations import get_claim_category, approved_amount
 from medical.test_helpers import get_item_of_type, get_service_of_category
 
@@ -74,3 +74,21 @@ def delete_claim_with_itemsvc_dedrem_and_history(claim):
     claim.items.all().delete()
     claim.services.all().delete()
     claim.delete()
+
+
+def create_test_claim_admin(custom_props={}):
+    from core import datetime
+    return ClaimAdmin.objects.create(
+        **{
+            "code": "TST00001",
+            "last_name": "LastAdmin",
+            "other_names": "JoeAdmin",
+            "email_id": "joeadmin@lastadmin.com",
+            "phone": "+12027621401",
+            "health_facility_id": 1,
+            "has_login": False,
+            "audit_user_id": 1,
+            "validity_from": datetime.datetime(2019, 6, 1),
+            **custom_props
+        }
+    )


### PR DESCRIPTION
This command leverages the test data creation functions to generate lots of data, mainly for performance testing.
`manage.py generateclaims 5000 5 6 --verbose`
will generate 5000 claims with 5 services and 6 items and print verbose information about its progress.
The insurees, services and items are picked at random from the active records. The IDs are fetched all at start and kept in memory because SQL Server doesn't support `.order_by("?")[0]` and for performance reasons.

Future versions will add claim status to be set to processed, including dedrem computation (but skipping validation or it will become very hard).