### PR TITLE
Fix user district query

### DIFF
--- a/claim/models.py
+++ b/claim/models.py
@@ -1,5 +1,4 @@
 import uuid
-from functools import cached_property
 
 from claim_batch import models as claim_batch_models
 from core import fields, TimeUtils
@@ -281,7 +280,7 @@ class Claim(core_models.VersionedModel, core_models.ExtendableModel):
             else:
                 dist = UserDistrict.get_user_districts(user._u)
                 return queryset.filter(
-                    health_facility__location_id__in=dist.values_list("id", flat=True)
+                    health_facility__location_id__in=dist.values_list("location_id", flat=True)
                 )
         return queryset
 

--- a/claim/test_validations.py
+++ b/claim/test_validations.py
@@ -1,5 +1,5 @@
 from claim.gql_mutations import set_claims_status, update_claims_dedrems
-from claim.models import Claim, ClaimDedRem, ClaimItem, ClaimDetail
+from claim.models import Claim, ClaimDedRem, ClaimItem, ClaimDetail, ClaimService
 from claim.test_helpers import create_test_claim, create_test_claimservice, create_test_claimitem, \
     mark_test_claim_as_processed, delete_claim_with_itemsvc_dedrem_and_history
 from claim.validations import get_claim_category, validate_claim, validate_assign_prod_to_claimitems_and_services, \
@@ -998,7 +998,7 @@ class ValidationTest(TestCase):
 
         service1.qty_approved = 0
         service1.price_approved = 0
-        service1.status = ClaimItem.STATUS_REJECTED
+        service1.status = ClaimService.STATUS_REJECTED
         service1.rejection_reason = -1
         service1.audit_user_id_review = -1
         service1.justification = "Review comment svc"


### PR DESCRIPTION
The user districts were optimized some time ago but it was using the join table ID (UserDistrict) rather than the district IDs to filter on many queries.