### PR TITLE
District verification was using the wrong ID

### DIFF
--- a/claim/models.py
+++ b/claim/models.py
@@ -281,7 +281,7 @@ class Claim(core_models.VersionedModel, core_models.ExtendableModel):
             else:
                 dist = UserDistrict.get_user_districts(user._u)
                 return queryset.filter(
-                    health_facility__location_id__in=dist.values_list("id", flat=True)
+                    health_facility__location_id__in=dist.values_list("location_id", flat=True)
                 )
         return queryset
 


### PR DESCRIPTION
The claim security was considering the UserDistrict join table internal ID instead of the location_id.