### PR TITLE
OTC-792: fix service validation based on category

### DIFF
--- a/.github/workflows/openmis-module-test.yml
+++ b/.github/workflows/openmis-module-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install linux packages
         run: |
           git clone --depth 1 --branch develop https://github.com/openimis/database_ms_sqlserver.git  ./sql
-          cd sql/ && bash ./scriot/concatenate_files.sh && cd ..
+          cd sql/ && bash ./concatenate_files.sh && cd ..
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
           sudo apt-get update

--- a/.github/workflows/openmis-module-test.yml
+++ b/.github/workflows/openmis-module-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install linux packages
         run: |
           git clone --depth 1 --branch develop https://github.com/openimis/database_ms_sqlserver.git  ./sql
-          cd sql/ && bash concatenate_files.sh && cd ..
+          cd sql/ && bash ./scriot/concatenate_files.sh && cd ..
           curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
           curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
           sudo apt-get update

--- a/claim/test_validations.py
+++ b/claim/test_validations.py
@@ -259,8 +259,8 @@ class ValidationTest(TestCase):
 
         # Then
         claim1.refresh_from_db()
-        self.assertEquals(len(errors), 1)
-        self.assertEquals(errors[0]['code'], 1)  # claimed rejected because all services are rejected
+        self.assertGreaterEqual(len(errors), 1)
+        self.assertEquals(errors[-1]['code'], 1)  # claimed rejected because all services are rejected
         self.assertEquals(claim1.services.first().rejection_reason, 4)  # reason is wrong insuree mask
 
         # tearDown
@@ -543,7 +543,7 @@ class ValidationTest(TestCase):
         service1 = create_test_claimservice(claim1, custom_props={"service_id": service.id})
         errors = validate_claim(claim1, True)
 
-        self.assertEqual(len(errors), 1, "An adult visit within the waiting period should be refused")
+        self.assertGreaterEqual(len(errors), 1, "An adult visit within the waiting period should be refused")
         self.assertEqual(claim1.services.first().rejection_reason, REJECTION_REASON_WAITING_PERIOD_FAIL)
 
         # a visit after the waiting period should be fine


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-792

Now validation method uses category assigned to service instead of claim base category. It also adds corresponding error messages.