### PR TITLE
OTC-1080: skipped depricated test for mssql when database is pssql

### DIFF
--- a/claim/test_services.py
+++ b/claim/test_services.py
@@ -115,6 +115,8 @@ class ClaimSubmitServiceTestCase(TestCase):
 
     @mock.patch('django.db.connections')
     def test_claim_submit_error(self, mock_connections):
+        if not connection.vendor == 'mssql':
+            self.skipTest("This test can only be executed for MSSQL database")
         with mock.patch("claim.services.ClaimSubmitService.hf_scope_check") as mock_security:
             mock_security.return_value = None
             query_result = [2]

--- a/claim/test_services.py
+++ b/claim/test_services.py
@@ -115,7 +115,7 @@ class ClaimSubmitServiceTestCase(TestCase):
 
     @mock.patch('django.db.connections')
     def test_claim_submit_error(self, mock_connections):
-        if not connection.vendor == 'mssql':
+        if connection.vendor != 'mssql':
             self.skipTest("This test can only be executed for MSSQL database")
         with mock.patch("claim.services.ClaimSubmitService.hf_scope_check") as mock_security:
             mock_security.return_value = None


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1080

Changes:
- the test case "test_claim_submit_error" was failing on PostgreSQL because it was executing SQL statements designed for MSSQL. The test is now skipped when the database connection is PostgreSQL. It is recommended to consider deleting the test case since the README file states that the "submit" function is deprecated.