### PR TITLE
ONI-70: Explanation mandatory if service quantity>1.

### DIFF
--- a/claim/apps.py
+++ b/claim/apps.py
@@ -52,6 +52,7 @@ class ClaimConfig(AppConfig):
     gql_mutation_delete_claims_perms = []
     claim_print_perms = []
     claim_attachments_root_path = None
+    claim_validation_multiple_services_explanation_required = True
 
     def _configure_perms(self, cfg):
         ClaimConfig.default_validations_disabled = cfg["default_validations_disabled"]

--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -275,6 +275,10 @@ def create_attachments(claim_id, attachments):
 def update_or_create_claim(data, user):
     items = data.pop('items') if 'items' in data else []
     services = data.pop('services') if 'services' in data else []
+    if ClaimConfig.claim_validation_multiple_services_explanation_required:
+        for service in services:
+            if service["qty_provided"] > 1 and not service.get("explanation"):
+                raise ValidationError(_("mutation.service_explanation_required"))
     incoming_code = data.get('code')
     claim_uuid = data.pop("uuid", None)
     current_claim = Claim.objects.filter(uuid=claim_uuid).first()


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-70

Connected PR: https://github.com/openimis/openimis-fe-claim_js/pull/100

Changes:
- Added setting for mandatory explanations of services,
- If true, service explanation is mandatory if quantity>1.
