### PR TITLE
OP-1494: use pricelist detail from submitting a claim when processing

### DIFF
--- a/claim/test_validations.py
+++ b/claim/test_validations.py
@@ -10,7 +10,8 @@ from insuree.models import Family, Insuree
 from insuree.test_helpers import create_test_insuree
 from location.models import HealthFacility
 from medical.test_helpers import create_test_service, create_test_item
-from medical_pricelist.test_helpers import add_service_to_hf_pricelist, add_item_to_hf_pricelist
+from medical_pricelist.test_helpers import add_service_to_hf_pricelist, add_item_to_hf_pricelist, \
+    update_service_in_hf_pricelist, update_item_in_hf_pricelist
 from policy.test_helpers import create_test_policy
 
 # default arguments should not pass a list or a dict because they're mutable but we don't risk mutating them here:
@@ -1026,6 +1027,83 @@ class ValidationTest(TestCase):
         # tearDown
         # dedrem.delete() # already done if the test passed
         delete_claim_with_itemsvc_dedrem_and_history(claim1)
+        policy.insuree_policies.first().delete()
+        policy.delete()
+        product_item.delete()
+        product_service.delete()
+        pricelist_detail1.delete()
+        pricelist_detail2.delete()
+        service.delete()
+        item.delete()
+        product.delete()
+
+    def test_submit_claim_dedrem_update_pricelist_detail(self):
+        '''
+        This test replicates the functionality of test_submit_claim_dedrem,
+        with the additional step of updating items and services prior to dedrem calculation.
+        Despite the updates, the results should remain unaffected as the prices
+        for these services/items are sourced from the pricelist detail's state at the time of claim submission.
+        '''
+        insuree = create_test_insuree()
+        self.assertIsNotNone(insuree)
+        product = create_test_product("VISIT", custom_props={})
+        policy = create_test_policy(product, insuree, link=True)
+        service = create_test_service("V", custom_props={})
+        item = create_test_item("D", custom_props={})
+        product_service = create_test_product_service(product, service)
+        product_item = create_test_product_item(product, item)
+        pricelist_detail1 = add_service_to_hf_pricelist(service)
+        pricelist_detail2 = add_item_to_hf_pricelist(item)
+
+        claim1 = create_test_claim({"insuree_id": insuree.id})
+        service1 = create_test_claimservice(
+            claim1, custom_props={"service_id": service.id})
+        item1 = create_test_claimitem(
+            claim1, "D", custom_props={"item_id": item.id})
+        errors = validate_claim(claim1, True)
+        errors += validate_assign_prod_to_claimitems_and_services(claim1)
+        update_service_in_hf_pricelist(service.id, custom_props={"price_overrule": 21})
+        update_item_in_hf_pricelist(item.id, custom_props={"price_overrule": 37})
+        errors += process_dedrem(claim1, -1, True)
+        self.assertEqual(len(errors), 0)
+
+        # Then
+        claim1.refresh_from_db()
+        item1.refresh_from_db()
+        service1.refresh_from_db()
+        self.assertEqual(len(errors), 0)
+        self.assertEqual(item1.price_adjusted, 100)
+        self.assertEqual(item1.price_valuated, 700)
+        self.assertEqual(item1.deductable_amount, 0)
+        self.assertEqual(item1.exceed_ceiling_amount, 0)
+        self.assertIsNone(item1.exceed_ceiling_amount_category)
+        self.assertEqual(item1.remunerated_amount, 700)
+        self.assertEqual(claim1.status, Claim.STATUS_VALUATED)
+        self.assertEqual(claim1.audit_user_id_process, -1)
+        self.assertIsNotNone(claim1.process_stamp)
+        self.assertIsNotNone(claim1.date_processed)
+
+        dedrem_qs = ClaimDedRem.objects.filter(claim=claim1)
+        self.assertEqual(dedrem_qs.count(), 1)
+        dedrem1 = dedrem_qs.first()
+        self.assertEqual(dedrem1.policy_id, item1.policy_id)
+        self.assertEqual(dedrem1.insuree_id, claim1.insuree_id)
+        self.assertEqual(dedrem1.audit_user_id, -1)
+        self.assertEqual(dedrem1.ded_g, 0)
+        self.assertEqual(dedrem1.rem_g, 1400)
+        self.assertEqual(dedrem1.rem_op, 1400)
+        self.assertIsNone(dedrem1.rem_ip)
+        self.assertEqual(dedrem1.rem_surgery, 0)
+        self.assertEqual(dedrem1.rem_consult, 0)
+        self.assertEqual(dedrem1.rem_hospitalization, 0)
+        self.assertIsNotNone(claim1.validity_from)
+        self.assertIsNone(claim1.validity_to)
+
+        # tearDown
+        dedrem_qs.delete()
+        service1.delete()
+        item1.delete()
+        claim1.delete()
         policy.insuree_policies.first().delete()
         policy.delete()
         product_item.delete()

--- a/claim/test_validations.py
+++ b/claim/test_validations.py
@@ -11,7 +11,7 @@ from insuree.test_helpers import create_test_insuree
 from location.models import HealthFacility
 from medical.test_helpers import create_test_service, create_test_item
 from medical_pricelist.test_helpers import add_service_to_hf_pricelist, add_item_to_hf_pricelist, \
-    update_service_in_hf_pricelist, update_item_in_hf_pricelist
+    update_pricelist_service_detail_in_hf_pricelist, update_pricelist_item_detail_in_hf_pricelist
 from policy.test_helpers import create_test_policy
 
 # default arguments should not pass a list or a dict because they're mutable but we don't risk mutating them here:
@@ -1063,8 +1063,8 @@ class ValidationTest(TestCase):
             claim1, "D", custom_props={"item_id": item.id})
         errors = validate_claim(claim1, True)
         errors += validate_assign_prod_to_claimitems_and_services(claim1)
-        update_service_in_hf_pricelist(service.id, custom_props={"price_overrule": 21})
-        update_item_in_hf_pricelist(item.id, custom_props={"price_overrule": 37})
+        update_pricelist_service_detail_in_hf_pricelist(pricelist_detail1, custom_props={"price_overrule": 21})
+        update_pricelist_item_detail_in_hf_pricelist(pricelist_detail1, custom_props={"price_overrule": 37})
         errors += process_dedrem(claim1, -1, True)
         self.assertEqual(len(errors), 0)
 

--- a/claim/test_validations.py
+++ b/claim/test_validations.py
@@ -1042,7 +1042,8 @@ class ValidationTest(TestCase):
         This test replicates the functionality of test_submit_claim_dedrem,
         with the additional step of updating items and services prior to dedrem calculation.
         Despite the updates, the results should remain unaffected as the prices
-        for these services/items are sourced from the pricelist detail's state at the time of claim submission.
+        for these services/items are sourced from the pricelist detail's state at the time of
+        coalse(claim.dateto, claim.datefrom).
         '''
         insuree = create_test_insuree()
         self.assertIsNotNone(insuree)

--- a/claim/utils.py
+++ b/claim/utils.py
@@ -96,3 +96,12 @@ def __get_current_nepali_fiscal_year_code():
 
     year_code = str(current_year) + "-" + str(current_year+1)[-3:] + "-"
     return year_code
+
+def get_instance_valid_at_date(queryset, date):
+    filtered_qs = queryset.filter(
+        validity_to__gte=date,
+        validity_from__lte=date
+    )
+    if filtered_qs.exists():
+        return filtered_qs.first()
+    return queryset.filter(validity_to__isnull=True).first()

--- a/claim/utils.py
+++ b/claim/utils.py
@@ -97,11 +97,12 @@ def __get_current_nepali_fiscal_year_code():
     year_code = str(current_year) + "-" + str(current_year+1)[-3:] + "-"
     return year_code
 
-def get_instance_valid_at_date(queryset, date):
+
+def get_queryset_valid_at_date(queryset, date):
     filtered_qs = queryset.filter(
         validity_to__gte=date,
         validity_from__lte=date
     )
     if filtered_qs.exists():
-        return filtered_qs.first()
-    return queryset.filter(validity_to__isnull=True).first()
+        return filtered_qs
+    return queryset.filter(validity_from__lte=date, validity_to__isnull=True)

--- a/claim/validations.py
+++ b/claim/validations.py
@@ -16,7 +16,7 @@ from policy.models import Policy
 from product.models import Product, ProductItem, ProductService, ProductItemOrService
 
 from .apps import ClaimConfig
-from .utils import get_instance_valid_at_date
+from .utils import get_queryset_valid_at_date
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +219,7 @@ def validate_claimitem_in_price_list(claim, claimitem):
                 items_pricelist=claim.health_facility.items_pricelist,
                 items_pricelist__validity_to__isnull=True
                 )
-    pricelist_detail = get_instance_valid_at_date(pricelist_detail_qs, target_date)
+    pricelist_detail = get_queryset_valid_at_date(pricelist_detail_qs, target_date).first()
     if not pricelist_detail:
         claimitem.rejection_reason = REJECTION_REASON_NOT_IN_PRICE_LIST
         errors += [{'code': REJECTION_REASON_NOT_IN_PRICE_LIST,
@@ -238,7 +238,7 @@ def validate_claimservice_in_price_list(claim, claimservice):
                 services_pricelist=claim.health_facility.services_pricelist,
                 services_pricelist__validity_to__isnull=True
                 )
-    pricelist_detail = get_instance_valid_at_date(pricelist_detail_qs, target_date)
+    pricelist_detail = get_queryset_valid_at_date(pricelist_detail_qs, target_date).first()
     if not pricelist_detail:
         claimservice.rejection_reason = REJECTION_REASON_NOT_IN_PRICE_LIST
         errors += [{'code': REJECTION_REASON_NOT_IN_PRICE_LIST,
@@ -1106,7 +1106,7 @@ def process_dedrem(claim, audit_user_id=-1, is_process=False):
                         itemsvc=claim_detail.itemsvc,
                         itemsvcs_pricelist__validity_to__isnull=True,
                         )
-            itemsvc_pricelist_detail = get_instance_valid_at_date(itemsvc_pricelist_detail_qs, target_date)
+            itemsvc_pricelist_detail = get_queryset_valid_at_date(itemsvc_pricelist_detail_qs, target_date).first()
             product_itemsvc = None
 
             if detail_is_item:


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-1494

This PR assures that values for items and services used in processing of a claim are the same as they were when claim was submitted.

This needs to be merged first so tests would pass: https://github.com/openimis/openimis-be-medical_pricelist_py/pull/32