### PR TITLE
fix(claim): fix calucalation of frequency limit

### DIFF
--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -882,7 +882,7 @@ class SaveClaimReviewMutation(OpenIMISMutation):
                 claim.services.filter(id=service_id).update(**service)
                 for claim_service_service in service_service_set:
                     claim_service_code = claim_service_service.pop(
-                        'subServiceCode')
+                        'sub_service_code')
                     claim_service = claim.services.filter(
                         id=service_id).first()
                     if claim_service:
@@ -910,7 +910,7 @@ class SaveClaimReviewMutation(OpenIMISMutation):
                                     **claim_service_service)
                         claim_service_elements.append(claim_service)
                 for claim_service_item in service_item_set:
-                    claim_item_code = claim_service_item.pop('subItemCode')
+                    claim_item_code = claim_service_item.pop('sub_item_code')
                     claim_service = claim.services.filter(
                         id=service_id).first()
                     if claim_service:

--- a/claim/validations.py
+++ b/claim/validations.py
@@ -308,7 +308,7 @@ def frequency_check(qs, claim, elt):
         .annotate(target_date=Coalesce("claim__date_to", "claim__date_from")) \
         .filter(Q(rejection_reason=0) | Q(rejection_reason__isnull=True),
                 validity_to__isnull=True,
-                target_date__gte=td - delta,
+                target_date__range=(td - delta, td),
                 status=ClaimDetail.STATUS_PASSED,
                 claim__insuree_id=claim.insuree_id,
                 claim__status__gt=Claim.STATUS_ENTERED


### PR DESCRIPTION
We found that some users may submit claims out of chronological order. When this happens, and there's a frequency set on the product, the system may be unable to submit the older claims. To address this, we use the "between" approach as a fix.