### PR TITLE
feat : fix on  PLItemServDetails #OICI-81

### DIFF
--- a/claim/validations.py
+++ b/claim/validations.py
@@ -223,7 +223,7 @@ def validate_claimitem_in_price_list(claim, claimitem):
     target_date = get_claim_target_date(claim)
     pricelist_detail_qs = ItemsPricelistDetail.objects \
         .filter(item_id=claimitem.item_id,
-                 *filter_validity(validity=target_date)
+                 *filter_validity(validity=target_date),
                 items_pricelist=claim.health_facility.items_pricelist,
                 items_pricelist__validity_to__isnull=True
                 )
@@ -242,7 +242,7 @@ def validate_claimservice_in_price_list(claim, claimservice):
     target_date = get_claim_target_date(claim)
     pricelist_detail_qs = ServicesPricelistDetail.objects \
         .filter(service_id=claimservice.service_id,
-                 *filter_validity(validity=target_date)
+                 *filter_validity(validity=target_date),
                 services_pricelist=claim.health_facility.services_pricelist,
                 services_pricelist__validity_to__isnull=True
                 )

--- a/claim/validations.py
+++ b/claim/validations.py
@@ -223,8 +223,7 @@ def validate_claimitem_in_price_list(claim, claimitem):
     target_date = get_claim_target_date(claim)
     pricelist_detail_qs = ItemsPricelistDetail.objects \
         .filter(item_id=claimitem.item_id,
-                validity_to__gte=target_date,
-                validity_from__lte=target_date,
+                 *filter_validity(validity=target_date)
                 items_pricelist=claim.health_facility.items_pricelist,
                 items_pricelist__validity_to__isnull=True
                 )

--- a/claim/validations.py
+++ b/claim/validations.py
@@ -242,8 +242,7 @@ def validate_claimservice_in_price_list(claim, claimservice):
     target_date = get_claim_target_date(claim)
     pricelist_detail_qs = ServicesPricelistDetail.objects \
         .filter(service_id=claimservice.service_id,
-                validity_to__gte=target_date,
-                validity_from__lte=target_date,
+                 *filter_validity(validity=target_date)
                 services_pricelist=claim.health_facility.services_pricelist,
                 services_pricelist__validity_to__isnull=True
                 )

--- a/claim/validations.py
+++ b/claim/validations.py
@@ -223,12 +223,12 @@ def validate_claimitem_in_price_list(claim, claimitem):
     target_date = get_claim_target_date(claim)
     pricelist_detail_qs = ItemsPricelistDetail.objects \
         .filter(item_id=claimitem.item_id,
-                validity_to__isnull=True,
+                validity_to__gte=target_date,
+                validity_from__lte=target_date,
                 items_pricelist=claim.health_facility.items_pricelist,
                 items_pricelist__validity_to__isnull=True
                 )
-    pricelist_detail = get_queryset_valid_at_date(pricelist_detail_qs, target_date).first()
-    if not pricelist_detail:
+    if not pricelist_detail_qs:
         claimitem.rejection_reason = REJECTION_REASON_NOT_IN_PRICE_LIST
         errors += [{'code': REJECTION_REASON_NOT_IN_PRICE_LIST,
                     'message': _("claim.validation.claimitem_in_price_list_validity") % {
@@ -243,11 +243,12 @@ def validate_claimservice_in_price_list(claim, claimservice):
     target_date = get_claim_target_date(claim)
     pricelist_detail_qs = ServicesPricelistDetail.objects \
         .filter(service_id=claimservice.service_id,
+                validity_to__gte=target_date,
+                validity_from__lte=target_date,
                 services_pricelist=claim.health_facility.services_pricelist,
                 services_pricelist__validity_to__isnull=True
                 )
-    pricelist_detail = get_queryset_valid_at_date(pricelist_detail_qs, target_date).first()
-    if not pricelist_detail:
+    if not pricelist_detail_qs:
         claimservice.rejection_reason = REJECTION_REASON_NOT_IN_PRICE_LIST
         errors += [{'code': REJECTION_REASON_NOT_IN_PRICE_LIST,
                     'message': _("claim.validation.claimservice_in_price_list_validity") % {


### PR DESCRIPTION
Hello @dragos-dobre We’ve identified that users sometimes modify Services and Items within Price Lists, which can inadvertently update the validityFrom and validityTo dates in the database. As a result, the code was failing to retrieve the correct elements when submitting a claim.

To resolve this, we’ve updated the logic to ensure it retrieves elements that were valid on the claim date. We believe this fix addresses the issue.

Let us know if you have any questions or notice further inconsistencies.