### PR TITLE
Reject the claim item/service if the associated item/service has a validity start date that is later than the claim's target date.

### DIFF
--- a/claim/tests/test_validations.py
+++ b/claim/tests/test_validations.py
@@ -3,9 +3,10 @@ from claim.models import Claim, ClaimDedRem, ClaimItem, ClaimDetail, ClaimServic
 from claim.test_helpers import create_test_claim, create_test_claimservice, create_test_claimitem, \
     mark_test_claim_as_processed, delete_claim_with_itemsvc_dedrem_and_history
 from core.test_helpers import create_test_officer, create_test_interactive_user
+from datetime import date, timedelta, datetime
 
 from claim.validations import get_claim_category, validate_claim, validate_assign_prod_to_claimitems_and_services, \
-    process_dedrem, REJECTION_REASON_WAITING_PERIOD_FAIL, REJECTION_REASON_INVALID_ITEM_OR_SERVICE
+    process_dedrem, REJECTION_REASON_WAITING_PERIOD_FAIL, REJECTION_REASON_INVALID_ITEM_OR_SERVICE, REJECTION_REASON_TARGET_DATE
 from core.models import User, InteractiveUser
 from django.test import TestCase
 from insuree.models import Family, Insuree
@@ -1127,4 +1128,56 @@ class ValidationTest(TestCase):
         self.assertEqual(claimservice2.price_adjusted, 750)
         claimservice3.refresh_from_db()
         self.assertIsNone(claimservice3.price_adjusted)
+        
+    def test_validate_claimitem_future_validity(self):
+        # Given
+        future_date = date.today() + timedelta(days=30)
+        item_future = create_test_item("D", valid=True)
+        item_future.validity_from = future_date
+        item_future.save()
+
+        claim = create_test_claim({
+            "insuree_id": self.test_insuree.id,
+            "date_from": date.today(),
+            "date_to": date.today()
+        })
+        claim_item = create_test_claimitem(claim, custom_props={"item_id": item_future.id})
+
+        # When
+        errors = validate_claim(claim, check_max=True)
+
+        # Then
+        self.assertTrue(any(e['code'] == REJECTION_REASON_TARGET_DATE for e in errors), "Item validity should cause rejection")
+        claim_item.refresh_from_db()
+        self.assertEqual(claim_item.rejection_reason, REJECTION_REASON_TARGET_DATE, "Claim item should be rejected for future validity")
+
+        # tearDown
+        claim_item.delete()
+        claim.delete()
+        item_future.delete()
+
+    def test_validate_claimservice_future_validity(self):
+        # Given
+        future_date = date.today() + timedelta(days=30)
+        service_future = create_test_service("D", valid=True)
+        service_future.validity_from = future_date
+        service_future.save()
+
+        claim = create_test_claim({
+            "insuree_id": self.test_insuree.id,
+            "date_from": date.today(),
+            "date_to": date.today()
+        })
+        claim_service = create_test_claimservice(claim, custom_props={"service_id": service_future.id})
+        # When
+        errors = validate_claim(claim, check_max=True)
+        # Then
+        self.assertTrue(any(e['code'] == REJECTION_REASON_TARGET_DATE for e in errors), "Service validity should cause rejection")
+        claim_service.refresh_from_db()
+        self.assertEqual(claim_service.rejection_reason, REJECTION_REASON_TARGET_DATE, "Claim service should be rejected for future validity")
+        # tearDown
+        claim_service.delete()
+        claim.delete()
+        service_future.delete()
+        
    

--- a/claim/validations.py
+++ b/claim/validations.py
@@ -193,6 +193,7 @@ def validate_claimitem_validity(claim, claimitem):
     # gives no result, so no claimitem is pointing to an old item and the complex query always fetched the last one.
     # Here, claimitem.item.legacy_id is always None
     errors = []
+    target_date = get_claim_target_date(claim)
     if claimitem.validity_to is None and claimitem.item.validity_to is not None:
         claimitem.rejection_reason = REJECTION_REASON_INVALID_ITEM_OR_SERVICE
         errors += [{'code': REJECTION_REASON_INVALID_ITEM_OR_SERVICE,
@@ -200,12 +201,23 @@ def validate_claimitem_validity(claim, claimitem):
                         'code': claim.code
                     },
                     'detail': claim.uuid}]
+    elif claimitem.item.validity_from and claimitem.item.validity_from > target_date:
+        # Reject the claim item if the associated item has a validity start date that is later than the claim's target date.
+        claimitem.rejection_reason = REJECTION_REASON_TARGET_DATE
+        errors += [{
+            'code': REJECTION_REASON_TARGET_DATE,
+            'message': _("claim.validation.item_future_validity") % {
+                'code': claim.code
+            },
+            'detail': claim.uuid
+        }]
     return errors
 
 
 def validate_claimservice_validity(claim, claimservice):
     # See note in validate_claimitem_validity
     errors = []
+    target_date = get_claim_target_date(claim)
     if claimservice.validity_to is None and claimservice.service.validity_to is not None:
         claimservice.rejection_reason = REJECTION_REASON_INVALID_ITEM_OR_SERVICE
         errors += [{'code': REJECTION_REASON_INVALID_ITEM_OR_SERVICE,
@@ -213,6 +225,15 @@ def validate_claimservice_validity(claim, claimservice):
                         'code': claim.code
                     },
                     'detail': claim.uuid}]
+    elif claimservice.service.validity_from and claimservice.service.validity_from > target_date:
+        # Reject the claim service if the associated item has a validity start date that is later than the claim's target date.
+        claimservice.rejection_reason = REJECTION_REASON_TARGET_DATE
+        errors += [{
+            'code': REJECTION_REASON_TARGET_DATE,
+            'message': _("claim.validation.service_future_validity") % {
+                'code': claim.code
+            },
+            'detail': claim.uuid}]
     return errors
 
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -231,3 +231,9 @@ msgstr "Claim needs to be rejected to be restored"
 
 msgid "mutation.restored_from_does_not_exist"
 msgstr "The claim you want to restore does not exist"
+
+msgid "claim.validation.service_future_validity"
+msgstr "The service associated with claim %(code)s is not yet valid at the time of the claim"
+
+msgid "claim.validation.item_future_validity"
+msgstr "The item associated with claim %(code)s is not yet valid at the time of the claim"


### PR DESCRIPTION
Problem: During claim submission, an SQL integrity error `Cannot insert the value NULL into column 'PolicyID'` occurred when creating a DedRem entry.
Cause: The claim referenced a service not yet valid on the visit date, so no matching product/policy was found, resulting in a `NULL` `PolicyID`.
Solution: Add validation to reject claim lines with services or items whose validity starts after the claim date, preventing invalid DedRem creation.