### PR TITLE
update fallback document types when sent from FHIR for claim attachments

### DIFF
--- a/claim/gql_mutations.py
+++ b/claim/gql_mutations.py
@@ -297,8 +297,10 @@ def create_attachment(claim_id, data):
     data["claim_id"] = claim_id
     from core import datetime
     now = datetime.datetime.now()
-    general_type = data['general_type']
+    general_type = data['general_type'] if data.get("general_type") else GeneralClaimAttachmentType.FILE # default to adjust FHIR attachments type fallback to FILE
     data['module'] = 'claim'
+    if not data.get('predefined_type'):
+        data['predefined_type'] = 'default'  # default to adjust for FHIR predefined is fallbacked to default    
     if general_type == GeneralClaimAttachmentType.URL:
         parsed_url = urlparse(data['url'])
         if (ClaimConfig.allowed_domains_attachments and


### PR DESCRIPTION
Sent attachment from FHIR "supportingInfo" is not being saved due to absence of general type and predefined type, as fallback to support e-claiming