### PR TITLE
refactor(tests): replace deprecated assertEquals with assertEqual in …

### DIFF
--- a/claim/tests/test_validations.py
+++ b/claim/tests/test_validations.py
@@ -314,7 +314,7 @@ class ValidationTest(TestCase):
         errors = validate_claim(claim1, True)
 
         # Then
-        self.assertEquals(len(errors), 0)
+        self.assertEqual(len(errors), 0)
 
     def test_frequency(self):
         # When the insuree already reaches his limit of visits


### PR DESCRIPTION
…claim validations test

Update the assertion method from the deprecated assertEquals to the correct assertEqual to eliminate deprecation warnings and maintain code consistency with modern Python unittest practices. This change affects the test_validations.py file in the claim module, ensuring cleaner test execution without warnings.

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [x] Other, please specify: CI

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
