### PR TITLE
fix(migration): null orphaned FK refs before adding tblFeedbackPrompt constraints

### DIFF
--- a/claim/migrations/0025_auto_20231205_1455.py
+++ b/claim/migrations/0025_auto_20231205_1455.py
@@ -12,6 +12,26 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # Null out orphaned FK references before adding constraints so that
+        # pre-existing DB initialization data (e.g. demo dataset) with
+        # OfficerID / ClaimID values not present in their parent tables
+        # does not cause ForeignKeyViolation on the ALTER TABLE below.
+        migrations.RunSQL(
+            sql=(
+                'UPDATE "tblFeedbackPrompt" SET "OfficerID" = NULL '
+                'WHERE "OfficerID" IS NOT NULL '
+                'AND "OfficerID" NOT IN (SELECT "OfficerID" FROM "tblOfficer");'
+            ),
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql=(
+                'UPDATE "tblFeedbackPrompt" SET "ClaimID" = NULL '
+                'WHERE "ClaimID" IS NOT NULL '
+                'AND "ClaimID" NOT IN (SELECT "ClaimID" FROM "tblClaim");'
+            ),
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.AlterField(
             model_name="feedbackprompt",
             name="officer_id",


### PR DESCRIPTION
## Summary

- Fresh 25.10 install fails at `claim.0025_auto_20231205_1455` with `django.db.utils.IntegrityError: ForeignKeyViolation` on `tblFeedbackPrompt`
- The 25.10 DB initialization scripts populate `tblFeedbackPrompt` with rows whose `OfficerID=3` is not present in `tblOfficer`, and `ClaimID` values not present in `tblClaim`
- Migration 0025 converts both columns from `IntegerField` to `ForeignKey`, which causes PostgreSQL to validate ALL existing rows when adding the FK constraint — finding the orphaned references and rejecting the `ALTER TABLE`
- Fix: add two `RunSQL` steps that NULL out orphaned `OfficerID` / `ClaimID` values before the `AlterField` operations run. Both columns are already `null=True` so this is safe. On a clean DB the `UPDATE` affects 0 rows (fully idempotent)

## Error

```
psycopg2.errors.ForeignKeyViolation: insert or update on table "tblFeedbackPrompt" 
violates foreign key constraint "tblFeedbackPrompt_OfficerID_c47d859c_fk_tblOfficer_OfficerID"
DETAIL:  Key (OfficerID)=(3) is not present in table "tblOfficer".
```

## Workaround (for users blocked on a fresh install)

Run this SQL against the database before retrying `python manage.py migrate`:

```sql
UPDATE "tblFeedbackPrompt"
SET "OfficerID" = NULL
WHERE "OfficerID" IS NOT NULL
  AND "OfficerID" NOT IN (SELECT "OfficerID" FROM "tblOfficer");

UPDATE "tblFeedbackPrompt"
SET "ClaimID" = NULL
WHERE "ClaimID" IS NOT NULL
  AND "ClaimID" NOT IN (SELECT "ClaimID" FROM "tblClaim");
```

## Test plan

- [ ] Fresh install of 25.10 using `openimis-dist_dkr` default config — migrations should complete without error
- [ ] Verify `tblFeedbackPrompt` records with no matching officer are NULL'd rather than deleted
- [ ] Verify upgrade from a pre-25.10 instance with clean data is unaffected (UPDATE hits 0 rows)