### PR TITLE
Add Forge WO ship automation (push + PR + Forge sync)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ dist
 **/*.mo
 locale/__init__.py
 .idea/**
+
+# Forge-managed local artifacts (never commit)
+.forge-commit-ready
+.forge/project-id
+.cursor/hooks.json
+.cursor/hooks/
+.cursor/rules/forge-workflow.mdc

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ locale/__init__.py
 # Forge-managed local artifacts (never commit)
 .forge-commit-ready
 .forge/project-id
+.forge/last-ship-mcp.json
 .cursor/hooks.json
 .cursor/hooks/
 .cursor/rules/forge-workflow.mdc

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 This repository holds the files of the openIMIS Backend Claim reference module.
 It is dedicated to be deployed as a module of [openimis-be_py](https://github.com/openimis/openimis-be_py).
 
+## Forge work orders (ClaimsAdjudication)
+
+This fork participates in the **ClaimsAdjudication** Forge project. For every completed WO: push, open/update a PR, and set Forge status to `in_review` in the same flow.
+
+See **[docs/FORGE_WO_WORKFLOW.md](docs/FORGE_WO_WORKFLOW.md)** — one-command ship: `./scripts/forge-wo-ship.sh WO-XXX <work_order_uuid>`.
+
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 ## Code climate (develop branch)

--- a/docs/BASELINE_BENCHMARK.md
+++ b/docs/BASELINE_BENCHMARK.md
@@ -1,0 +1,218 @@
+# Claims module baseline benchmark (WO-001)
+
+**Project:** ClaimsAdjudication (REF-2091)  
+**Work order:** WO-001 — Baseline current behavior  
+**Module:** `openimis-be-claim_py` (this repo is a pluggable module of [openimis-be_py](https://github.com/openimis/openimis-be_py))  
+**Purpose:** Establish repeatable measurements of *current* behavior before modernization. Fill in the results tables after each run; do not change application code as part of recording baselines.
+
+## PRD measurement dimensions
+
+| Dimension | What to capture | Used in scenarios |
+|-----------|-----------------|-------------------|
+| Submission latency | Wall-clock time for submit path (GraphQL `submit_claims` or service `ClaimSubmitService.submit_claim`) | S1 |
+| Query latency | Wall-clock time for GraphQL resolver round-trip | S2, S3 |
+| Query count | Number of SQL queries per operation (`django.db.connection.queries` or `assertNumQueries` in tests) | S2, S3 |
+| Report runtime | Wall-clock time to generate claim report output | S4 |
+| Batch throughput | Claims processed per unit time via `process_claims` (and related batch run if applicable) | S5 |
+
+Record environment metadata on every run (see [Run metadata](#run-metadata)).
+
+---
+
+## Environment setup (non-production only)
+
+Run all steps against a **dedicated non-prod** openIMIS backend. Do not point benchmarks at production data or credentials.
+
+### Prerequisites
+
+1. **Backend assembly:** Clone and configure [openimis-be_py](https://github.com/openimis/openimis-be_py) with this claim module on the `develop` branch (or the same commit under test).
+2. **Database:** SQL Server (or the DB stack your openIMIS instance uses) with a **restorable snapshot** or disposable database. Restore from a anonymized/staging backup rather than connecting to production.
+3. **Dependencies:** Install module requirements from `setup.py` / the parent backend’s lockfile. Module CI is defined in `.github/workflows/ci.yml` (reusable workflow `openimis/openimis-be_py/.github/workflows/ci_module.yml@develop`).
+4. **Auth:** GraphQL calls need a user with claim permissions (see README configuration keys, e.g. `gql_mutation_submit_claims_perms`, `gql_query_claims_perms`).
+5. **Optional — synthetic volume:** Use the management command below to seed claims for list/query/batch scenarios.
+
+### Seed representative test data
+
+From the **parent backend** project root (where `manage.py` lives):
+
+```bash
+# Example: 500 claims, 3 services and 2 items each (adjust counts for your DB size)
+python manage.py generateclaims <nb_claims> <nb_services> <nb_items> --verbose
+```
+
+- Command implementation: `claim/management/commands/generateclaims.py`
+- Helpers: `claim/test_helpers.py` (`create_test_claim`, items, services)
+- Related: `claim/management/commands/generateclaimadmins.py`
+
+Ensure seed data includes claims in states needed for **submit** (entered/saved) and **process** (checked/submitted per your workflow).
+
+### Enable query counting (for S2/S3)
+
+In Django settings for the benchmark run only:
+
+```python
+DEBUG = True  # required for connection.queries; never in production
+```
+
+Or use Django’s `CaptureQueriesContext` / test `assertNumQueries` patterns in a one-off script under the parent backend.
+
+### GraphQL endpoint
+
+Use the parent backend GraphQL URL (typically `/api/graphql`). Authenticate with the same mechanism your environment uses (JWT, basic, etc.).
+
+---
+
+## Benchmark scenarios
+
+Each scenario uses **current** code paths in this module. Code references are for orientation when writing scripts or manual steps.
+
+| ID | Scenario | Primary interface | Code path (reference) |
+|----|----------|-------------------|------------------------|
+| **S1** | Claim submission | GraphQL `submit_claims` | `claim/gql_mutations.py` (`SubmitClaimsMutation`), `claim/services.py` (`ClaimSubmitService.submit_claim`) |
+| **S2** | Claim list query | GraphQL `claims` | `claim/schema.py` (`resolve_claims`), `claim/gql_queries.py` |
+| **S3** | Single claim lookup | GraphQL `claim` | `claim/schema.py` (`resolve_claim`) |
+| **S4** | Report generation | Report `claim_claim` / print | `claim/reports/claim.py`, `claim/report.py`, `ClaimReportService` (README) |
+| **S5** | Batch processing | GraphQL `process_claims` | `claim/gql_mutations.py` (`ProcessClaimsMutation`), `claim/services.py` (`processing_claim`) |
+
+### S1 — Claim submission
+
+**Procedure (outline):**
+
+1. Create or select N claims in submittable state (use test helpers or UI).
+2. Warm up once, then measure M iterations of `submit_claims` for a fixed claim UUID set.
+3. Record end-to-end latency (client → response) and optionally server-side timing from logs.
+
+**Example GraphQL shape (adjust to your schema):**
+
+```graphql
+mutation SubmitClaims($input: SubmitClaimsMutationInput!) {
+  submitClaims(input: $input) {
+    clientMutationId
+    internalId
+    internalCode
+  }
+}
+```
+
+### S2 — `claims` query (list)
+
+**Procedure:**
+
+1. Fix filter parameters (date range, HF, status) representative of production-like list views.
+2. Run the `claims` query with `first`/pagination matching a typical UI page size.
+3. Record latency and **query count** for one page.
+
+```graphql
+query Claims($first: Int, $after: String) {
+  claims(first: $first, after: $after) {
+  }
+}
+```
+
+### S3 — `claim` query (single)
+
+**Procedure:**
+
+1. Pick claim UUIDs that exist in seed data (with items/services attached).
+2. Run `claim(id: …)` or `claim(uuid: …)` repeatedly; record latency and query count.
+
+```graphql
+query Claim($uuid: String!) {
+  claim(uuid: $uuid) {
+    uuid
+    code
+    status
+  }
+}
+```
+
+### S4 — Report generation
+
+**Procedure:**
+
+1. Select a claim with items/services suitable for the `claim_claim` report template.
+2. Trigger report generation via the report module API or REST print endpoint (`claim/urls.py`, README `claim_print_perms`).
+3. Record wall-clock runtime until PDF/output is available.
+
+### S5 — `process_claims` execution (batch throughput)
+
+**Procedure:**
+
+1. Prepare B claims in **checked** (or the status your environment requires before processing).
+2. Invoke `process_claims` with batch size B; record total wall time and compute **claims per second**.
+3. If your deployment uses `claim_batch` batch runs for valuation, note that separately (out of scope for pure mutation timing unless required for your baseline definition).
+
+```graphql
+mutation ProcessClaims($input: ProcessClaimsMutationInput!) {
+  processClaims(input: $input) {
+    clientMutationId
+    internalId
+  }
+}
+```
+
+---
+
+## Results — run 1
+
+> Copy this section for each benchmark run (e.g. before/after upgrades).
+
+### Run metadata
+
+| Field | Value |
+|-------|--------|
+| Date (UTC) | _TBD_ |
+| Git commit (`openimis-be-claim_py`) | _TBD_ |
+| Parent backend (`openimis-be_py`) commit | _TBD_ |
+| DB size (approx. claims count) | _TBD_ |
+| Hardware / hosting | _TBD_ |
+| Runner (manual / script name) | _TBD_ |
+
+### Results table
+
+| Scenario | Submission latency (ms) | Query latency (ms) | Query count | Report runtime (ms) | Batch throughput (claims/s) | Notes |
+|----------|-------------------------|--------------------|-------------|---------------------|----------------------------|-------|
+| S1 Submit | | — | — | — | — | |
+| S2 `claims` | — | | | — | — | Pagination: _first=N_ |
+| S3 `claim` | — | | | — | — | UUID: _…_ |
+| S4 Report | — | — | — | | — | Report: `claim_claim` |
+| S5 `process_claims` | — | — | — | — | | Batch size B=_ |
+
+### PRD target comparison (fill when PRD targets are known)
+
+| Dimension | Baseline (this run) | PRD target | Meets target? |
+|-----------|---------------------|------------|---------------|
+| Submission latency | | | |
+| Query latency | | | |
+| Query count | | | |
+| Report runtime | | | |
+| Batch throughput | | | |
+
+---
+
+## Existing test and CI tooling
+
+| Asset | Location | Relevance |
+|-------|----------|-----------|
+| Unit / validation tests | `claim/tests/` | Behavior reference; not performance benchmarks |
+| Test helpers | `claim/test_helpers.py` | Programmatic claim creation |
+| CI | `.github/workflows/ci.yml` | Module test + Sonar on push/PR |
+| Data generator | `claim/management/commands/generateclaims.py` | Volume for S2–S5 |
+
+Module tests are intended to run from the **parent** backend test harness, not in isolation in this repo.
+
+---
+
+## Acceptance criteria checklist (WO-001)
+
+- [ ] Repeatable benchmark document covers S1–S5 (this file).
+- [ ] Results tables include all PRD dimensions (even if targets are missed).
+- [ ] Procedure is executable in non-prod without modifying production data.
+
+---
+
+## Next steps (after scaffold)
+
+1. Execute each scenario in your non-prod stack and fill **Results — run 1**.
+2. Optionally add a small benchmark script in the parent backend repo (kept out of this module until agreed).
+3. When results are complete, commit on branch `wo/WO-001-baseline` with message containing `[WO-001]` per Forge workflow.

--- a/docs/FORGE_WO_WORKFLOW.md
+++ b/docs/FORGE_WO_WORKFLOW.md
@@ -1,0 +1,85 @@
+# Forge work order ship workflow
+
+Standing process for **every** Forge work order (WO) in ClaimsAdjudication.
+
+| Item | Value |
+|------|--------|
+| Forge project | ClaimsAdjudication `5fc679ab-b55c-441c-848d-2b5435a7462d` |
+| GitHub fork | [alekhyaakkiraju-droid/ClaimsAdjudication](https://github.com/alekhyaakkiraju-droid/ClaimsAdjudication) |
+| Default PR base | `develop` |
+| Branch pattern | `wo/WO-XXX-short-description` |
+
+## One-command ship (after commit)
+
+```bash
+# WO label from branch wo/WO-001-baseline → auto-detects WO-001
+./scripts/forge-wo-ship.sh WO-001 9e41bfef-ff94-45d1-8f10-65e6d47240ca
+```
+
+What the script does:
+
+1. `git push -u origin <current-branch>`
+2. `gh pr create` or reuse existing PR for the branch
+3. Writes `.forge/last-ship-mcp.json` with payloads for Forge MCP
+
+Then the agent (or you) **must** still call Forge MCP in the same session:
+
+- `create_pull_request` — record PR in Forge  
+- `update_work_order` — `status: in_review` + dev-activity fields  
+
+## Full WO completion flow (agents)
+
+1. Implement WO; validate acceptance criteria  
+2. `prepare_commit` (Forge MCP)  
+3. `git commit -m "[WO-XXX] …"` (pre-commit hook runs checklist)  
+4. `./scripts/forge-wo-ship.sh WO-XXX <uuid>`  
+5. `create_pull_request` + `update_work_order` (status `in_review`)  
+6. Report PR URL to user  
+
+## Setup (once per clone)
+
+```bash
+# Forge session
+# MCP: set_project({ project_id: "5fc679ab-b55c-441c-848d-2b5435a7462d" })
+# MCP: configure_repo({ ide: "cursor" })
+
+./scripts/install-forge-cursor.sh
+mkdir -p .forge
+echo "5fc679ab-b55c-441c-848d-2b5435a7462d" > .forge/project-id
+```
+
+Optional env for local Forge REST (MCP remains canonical):
+
+- `FORGE_API_TOKEN` or `FORGE_TOKEN`  
+- `FORGE_API_URL` (default `http://127.0.0.1:3001`)  
+
+## Cursor integration
+
+| Artifact | Location | Committed? |
+|----------|----------|------------|
+| Agent rule | `.cursor/rules/forge-workflow.mdc` | No (install from template) |
+| Pre-commit hook | `.cursor/hooks/forge-pre-commit.sh` | No |
+| Ship reminder | `.cursor/hooks/forge-ship-reminder.sh` | No (stop hook, WO branches only) |
+| Templates | `scripts/forge-cursor-templates/` | Yes |
+| Ship script | `scripts/forge-wo-ship.sh` | Yes |
+
+Install local hooks/rules:
+
+```bash
+./scripts/install-forge-cursor.sh
+```
+
+## WO UUID lookup
+
+```bash
+# Forge MCP
+list_work_orders → find label wo:WO-XXX → copy id
+```
+
+Example: WO-001 → `9e41bfef-ff94-45d1-8f10-65e6d47240ca`
+
+## Rules
+
+- One commit per WO; message contains `[WO-XXX]`  
+- Never force-push  
+- Push + PR + Forge `in_review` happen together on completion — not optional  

--- a/scripts/forge-cursor-templates/hooks.json
+++ b/scripts/forge-cursor-templates/hooks.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/forge-pre-commit.sh",
+        "matcher": "git commit",
+        "timeout": 10
+      }
+    ],
+    "stop": [
+      {
+        "command": ".cursor/hooks/forge-ship-reminder.sh",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/scripts/forge-cursor-templates/hooks/forge-pre-commit.sh
+++ b/scripts/forge-cursor-templates/hooks/forge-pre-commit.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Forge pre-commit hook for Cursor Agent.
+#
+# Only activates for work-order commits (message contains [TASK-] or [WO-]).
+# Regular commits pass through unblocked.
+#
+# Protocol: receives JSON on stdin, writes JSON to stdout.
+# Exit 0 = use returned JSON; exit 2 = hard deny.
+#
+# Coordination with .git/hooks/commit-msg:
+#   This hook ONLY peeks at the marker — it never deletes it. The native
+#   commit-msg hook is the canonical authority and consumes the marker after
+#   the commit message is validated. If we deleted it here, the commit-msg
+#   hook would then block the commit because the marker would be gone by the
+#   time git invokes it.
+
+input=$(cat)
+
+if ! echo "$input" | grep -qE '\[(TASK|WO)-'; then
+  echo '{"permission": "allow"}'
+  exit 0
+fi
+
+PROJECT_DIR="${CURSOR_PROJECT_DIR:-.}"
+MARKER="$PROJECT_DIR/.forge-commit-ready"
+
+if [ -f "$MARKER" ]; then
+  echo '{"permission": "allow"}'
+  exit 0
+fi
+
+cat << 'DENY'
+{
+  "permission": "deny",
+  "user_message": "Forge pre-commit checklist must be completed before committing.",
+  "agent_message": "FORGE PRE-COMMIT CHECKLIST — You must complete ALL steps below before the commit can proceed.\n\n## Step 1 — Unit Tests\n1. Run `git diff --cached --name-only` to get the list of staged files.\n2. For each staged source file, determine whether a corresponding unit test file exists (e.g., `foo.ts` → `foo.test.ts` or `foo.spec.ts`).\n3. If a test file is MISSING, auto-generate a unit test file for it.\n4. Run the full test suite for all affected test files.\n5. If any test FAILS:\n   a. Attempt to auto-fix the test.\n   b. If the fix requires changes to business/production logic (not just test code), you MUST ask the user for consent before making the change.\n   c. Re-run the tests to confirm they pass.\n\n## Step 2 — Acceptance Criteria Validation\n1. Call the Forge MCP `get_work_order` tool to retrieve the full work order, including its acceptance criteria.\n2. For each acceptance criterion, reason through whether your implementation satisfies it.\n   Use your knowledge of the changes you just made — you do NOT need to run `git diff` for this.\n3. For each criterion, determine: pass / partial / fail, with a one-sentence rationale.\n4. If any criterion is NOT fully satisfied:\n   a. State which criteria are unmet and why.\n   b. Ask the user how to proceed before continuing.\n5. Once all criteria are satisfied, proceed to Step 3.\n   Keep your validation summary — you will include it in the `commit_summary` field in Step 3.\n\n## Step 3 — Report to Forge\nUse the Forge MCP `update_work_order` tool to update the work order with:\n- `work_order_id`: the current work order ID\n- `commit_summary`: a brief description of the changes being committed\n- `test_summary`: summary of test execution (how many tests ran, passed, failed, auto-generated)\n\nYou MUST also include these structured fields for activity tracking:\n- `repo_url`: the remote origin URL (run `git remote get-url origin`)\n- `repo_name`: owner/repo extracted from the URL\n- `branch_name`: current branch (run `git branch --show-current`)\n- `commit_hash`: the full SHA of the commit being made (use `git rev-parse HEAD` after committing, or the staged commit SHA)\n- `commit_message`: the commit message text\n- `commit_author`: author name (run `git config user.name`)\n- `files_changed`: number of files changed (from `git diff --cached --stat`)\n- `lines_added`: total lines added\n- `lines_removed`: total lines removed\n- `changed_files`: array of objects with `path`, `additions`, and `deletions` per file (from `git diff --cached --numstat`)\n- `tests_total`: total number of tests run\n- `tests_passed`: number of tests that passed\n- `tests_failed`: number of tests that failed\n- `tests_skipped`: number of tests skipped (0 if none)\n- `test_coverage`: code coverage percentage if available (0-100), omit if not available\n\n## Step 4 — Mark Ready\nAfter ALL steps above are complete, create a file called `.forge-commit-ready` in the project root (write the text 'ready' to it), then retry the exact same `git commit` command."
+}
+DENY
+exit 0

--- a/scripts/forge-cursor-templates/hooks/forge-ship-reminder.sh
+++ b/scripts/forge-cursor-templates/hooks/forge-ship-reminder.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# After agent stop: nudge ship flow when on a WO branch with unpushed commits or no PR yet.
+# Never blocks; only adds context when conditions match.
+
+input=$(cat)
+BRANCH="$(git branch --show-current 2>/dev/null || true)"
+
+if ! echo "$BRANCH" | grep -qE '^wo/WO-[0-9]+'; then
+  exit 0
+fi
+
+WO="$(echo "$BRANCH" | sed -E 's#^wo/(WO-[0-9]+).*#\1#')"
+NEEDS=""
+
+if git rev-parse '@{u}' >/dev/null 2>&1; then
+  AHEAD="$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+  [[ "$AHEAD" != "0" ]] && NEEDS="push"
+else
+  NEEDS="push"
+fi
+
+if ! command -v gh >/dev/null 2>&1 || ! gh pr view >/dev/null 2>&1; then
+  NEEDS="${NEEDS:+$NEEDS, }open PR"
+fi
+
+[[ -n "$NEEDS" ]] || exit 0
+
+cat <<EOF
+{"followup_message":"WO ship reminder ($WO): run \`./scripts/forge-wo-ship.sh $WO <work_order_uuid>\` then Forge MCP \`create_pull_request\` + \`update_work_order\` (status in_review). See docs/FORGE_WO_WORKFLOW.md."}
+EOF
+exit 0

--- a/scripts/forge-cursor-templates/rules/forge-workflow.mdc
+++ b/scripts/forge-cursor-templates/rules/forge-workflow.mdc
@@ -1,0 +1,40 @@
+---
+description: Mandatory Forge WO ship workflow — push, PR, and Forge update together on every WO completion.
+alwaysApply: true
+---
+
+# Forge WO Ship Workflow (ClaimsAdjudication)
+
+**Project:** `5fc679ab-b55c-441c-848d-2b5435a7462d` (ClaimsAdjudication)  
+**Fork:** `alekhyaakkiraju-droid/ClaimsAdjudication`  
+**Branch pattern:** `wo/WO-XXX-short-description`
+
+## On every work order completion (MANDATORY)
+
+Do **not** stop after commit. In **one continuous flow**:
+
+1. **`prepare_commit`** (Forge MCP) — only after acceptance criteria are satisfied; use returned message.
+2. **`git commit`** with `[WO-XXX]` in the message (Forge pre-commit hook enforces checklist).
+3. **`./scripts/forge-wo-ship.sh WO-XXX <work_order_uuid>`** — pushes branch and creates/updates GitHub PR (`develop` base on fork).
+4. **Forge MCP (same turn, immediately after ship script):**
+   - `create_pull_request` — pass `work_order_id`, `branch_name`, `repo_url`, `repo_name`, `pr_url`, `pr_number`, `changes_summary`
+   - `update_work_order` — `status: in_review` plus all dev-activity fields from `.forge/last-ship-mcp.json` / git commands
+5. Confirm PR URL and Forge status `in_review` to the user.
+
+Never force-push. Never skip push, PR, or Forge update for a completed WO.
+
+## Branching
+
+- One commit per WO; branch name includes WO id: `wo/WO-XXX-kebab-title`
+- Base new branches on fork `develop` (not upstream `openimis/openimis-be-claim_py` unless explicitly requested)
+
+## Before first WO in a clone
+
+1. `set_project` with ClaimsAdjudication project id  
+2. `configure_repo` (`ide: cursor`) or `./scripts/install-forge-cursor.sh`  
+3. Ensure `.forge/project-id` contains the project UUID (from `set_project`)
+
+## Python module conventions
+
+- Match existing `claim/` patterns; run tests from parent `openimis-be_py` when applicable
+- Do not commit `.forge-commit-ready`, `.forge/last-ship-mcp.json`, or `.cursor/hooks*` (gitignored)

--- a/scripts/forge-wo-ship.sh
+++ b/scripts/forge-wo-ship.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Push branch, create/update GitHub PR, and print Forge MCP payloads for in_review + PR registration.
+# Usage:
+#   ./scripts/forge-wo-ship.sh WO-001 [work_order_uuid]
+#   ./scripts/forge-wo-ship.sh --wo-uuid <uuid> [--label WO-001]
+#
+# Env: FORGE_PROJECT_ID or .forge/project-id; FORGE_API_TOKEN or FORGE_TOKEN (optional REST);
+#      FORGE_API_URL (default http://127.0.0.1:3001); GH_BASE (default: origin default branch).
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "Not inside a git repository." >&2; exit 1; }
+cd "$ROOT"
+
+die() { echo "forge-wo-ship: $*" >&2; exit 1; }
+
+WO_LABEL=""
+WO_UUID="${FORGE_WORK_ORDER_ID:-}"
+GH_BASE="${GH_BASE:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --wo-uuid) WO_UUID="${2:?}"; shift 2 ;;
+    --label) WO_LABEL="${2:?}"; shift 2 ;;
+    --base) GH_BASE="${2:?}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,8p' "$0"
+      exit 0
+      ;;
+    WO-*|wo:WO-*)
+      WO_LABEL="${1#wo:}"
+      shift
+      ;;
+    *)
+      if [[ -z "$WO_UUID" && "$1" =~ ^[0-9a-f-]{36}$ ]]; then
+        WO_UUID="$1"
+      elif [[ -z "$WO_LABEL" && "$1" =~ ^WO-[0-9]+$ ]]; then
+        WO_LABEL="$1"
+      else
+        die "Unknown argument: $1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+BRANCH="$(git branch --show-current)"
+if [[ -z "$WO_LABEL" && "$BRANCH" =~ ^wo/(WO-[0-9]+) ]]; then
+  WO_LABEL="${BASH_REMATCH[1]}"
+fi
+[[ -n "$WO_LABEL" ]] || die "Work order label required (e.g. WO-001) or use branch wo/WO-NNN-*"
+
+PROJECT_ID="${FORGE_PROJECT_ID:-}"
+if [[ -f "$ROOT/.forge/project-id" ]]; then
+  PROJECT_ID="$(head -n 1 "$ROOT/.forge/project-id" | tr -d '\r\n')"
+fi
+[[ -n "$PROJECT_ID" ]] || die "Set FORGE_PROJECT_ID or create .forge/project-id"
+
+command -v gh >/dev/null 2>&1 || die "gh CLI is required"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+
+REPO_URL="$(git remote get-url origin 2>/dev/null || true)"
+REPO_NAME="$(echo "$REPO_URL" | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+).*#\1#; s#\.git$##')"
+COMMIT_HASH="$(git rev-parse HEAD)"
+COMMIT_MSG="$(git log -1 --pretty=%B)"
+COMMIT_AUTHOR="$(git config user.name 2>/dev/null || true)"
+
+if git rev-parse HEAD~1 >/dev/null 2>&1; then
+  DIFF_RANGE="HEAD~1"
+else
+  DIFF_RANGE="HEAD"
+fi
+
+STAT_LINE="$(git diff "$DIFF_RANGE" --stat 2>/dev/null | tail -1 || true)"
+FILES_CHANGED="$(echo "$STAT_LINE" | awk '{print $1}' | grep -E '^[0-9]+$' || echo 0)"
+[[ "$FILES_CHANGED" != "0" ]] || FILES_CHANGED="$(git diff "$DIFF_RANGE" --name-only 2>/dev/null | wc -l | tr -d ' ')"
+
+LINES_ADDED=0
+LINES_REMOVED=0
+CHANGED_FILES_JSON="[]"
+if git rev-parse HEAD~1 >/dev/null 2>&1; then
+  while IFS=$'\t' read -r add del path; do
+    [[ -n "$path" ]] || continue
+    LINES_ADDED=$((LINES_ADDED + add))
+    LINES_REMOVED=$((LINES_REMOVED + del))
+    CHANGED_FILES_JSON="$(echo "$CHANGED_FILES_JSON" | jq --arg p "$path" --argjson a "$add" --argjson d "$del" \
+      '. + [{path:$p, additions:$a, deletions:$d}]')"
+  done < <(git diff HEAD~1 --numstat)
+fi
+
+if [[ -z "$GH_BASE" ]]; then
+  GH_BASE="$(gh repo view "$REPO_NAME" --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo develop)"
+fi
+
+echo "==> Pushing $BRANCH to origin"
+git push -u origin "$BRANCH"
+
+PR_URL=""
+PR_NUMBER=""
+if PR_JSON="$(gh pr view --json url,number 2>/dev/null)"; then
+  PR_URL="$(echo "$PR_JSON" | jq -r .url)"
+  PR_NUMBER="$(echo "$PR_JSON" | jq -r .number)"
+  echo "==> Existing PR #$PR_NUMBER: $PR_URL"
+else
+  TITLE="[$WO_LABEL] $(git log -1 --pretty=%s)"
+  BODY_FILE="$(mktemp)"
+  cat >"$BODY_FILE" <<EOF
+## Summary
+Ship work order **$WO_LABEL** from branch \`$BRANCH\`.
+
+## Test plan
+- [ ] CI checks pass on this PR
+- [ ] Acceptance criteria for $WO_LABEL verified in Forge
+
+---
+_Forge: ClaimsAdjudication ($PROJECT_ID)_
+EOF
+  echo "==> Creating PR (base: $GH_BASE)"
+  PR_URL="$(gh pr create --base "$GH_BASE" --head "$BRANCH" --title "$TITLE" --body-file "$BODY_FILE")"
+  rm -f "$BODY_FILE"
+  PR_NUMBER="$(gh pr view --json number -q .number)"
+  echo "==> Created PR #$PR_NUMBER: $PR_URL"
+fi
+
+# Optional Forge REST (local Forge server); MCP is the canonical path when REST is unavailable.
+API_URL="${FORGE_API_URL:-http://127.0.0.1:3001}"
+TOKEN="${FORGE_API_TOKEN:-${FORGE_TOKEN:-}}"
+if [[ -n "$TOKEN" && -n "$WO_UUID" ]]; then
+  PAYLOAD="$(jq -n \
+    --arg status "in_review" \
+    --arg branch "$BRANCH" \
+    --arg repo_url "$REPO_URL" \
+    --arg repo_name "$REPO_NAME" \
+    --arg commit_hash "$COMMIT_HASH" \
+    --arg commit_message "$COMMIT_MSG" \
+    --arg commit_author "$COMMIT_AUTHOR" \
+    --arg pr_url "$PR_URL" \
+    --argjson pr_number "${PR_NUMBER:-null}" \
+    --argjson files_changed "${FILES_CHANGED:-0}" \
+    --argjson lines_added "$LINES_ADDED" \
+    --argjson lines_removed "$LINES_REMOVED" \
+    '{status:$status, branch_name:$branch, repo_url:$repo_url, repo_name:$repo_name,
+      commit_hash:$commit_hash, commit_message:$commit_message, commit_author:$commit_author,
+      pr_url:$pr_url, pr_number:$pr_number, files_changed:$files_changed,
+      lines_added:$lines_added, lines_removed:$lines_removed}')"
+  if curl -sf -X PATCH "$API_URL/projects/$PROJECT_ID/work-orders/$WO_UUID" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" >/dev/null 2>&1; then
+    echo "==> Forge REST: work order set to in_review"
+  else
+    echo "==> Forge REST unavailable (use MCP below)"
+  fi
+fi
+
+MCP_FILE="$ROOT/.forge/last-ship-mcp.json"
+mkdir -p "$ROOT/.forge"
+jq -n \
+  --arg wo_label "$WO_LABEL" \
+  --arg wo_uuid "$WO_UUID" \
+  --arg project_id "$PROJECT_ID" \
+  --arg branch "$BRANCH" \
+  --arg repo_url "$REPO_URL" \
+  --arg repo_name "$REPO_NAME" \
+  --arg pr_url "$PR_URL" \
+  --argjson pr_number "${PR_NUMBER:-null}" \
+  --arg commit_hash "$COMMIT_HASH" \
+  --arg commit_message "$COMMIT_MSG" \
+  --arg commit_author "$COMMIT_AUTHOR" \
+  --argjson files_changed "${FILES_CHANGED:-0}" \
+  --argjson lines_added "$LINES_ADDED" \
+  --argjson lines_removed "$LINES_REMOVED" \
+  --argjson changed_files "$CHANGED_FILES_JSON" \
+  '{
+    instructions: "Run these Forge MCP tools in order (set_project if needed):",
+    set_project: {project_id: $project_id},
+    create_pull_request: {
+      work_order_id: (if $wo_uuid != "" then $wo_uuid else "LOOKUP_VIA_get_work_order"),
+      branch_name: $branch,
+      repo_url: $repo_url,
+      repo_name: $repo_name,
+      pr_url: $pr_url,
+      pr_number: $pr_number,
+      changes_summary: ("Shipped " + $wo_label)
+    },
+    update_work_order: {
+      work_order_id: (if $wo_uuid != "" then $wo_uuid else "LOOKUP_VIA_get_work_order"),
+      status: "in_review",
+      branch_name: $branch,
+      repo_url: $repo_url,
+      repo_name: $repo_name,
+      commit_hash: $commit_hash,
+      commit_message: $commit_message,
+      commit_author: $commit_author,
+      pr_url: $pr_url,
+      pr_number: $pr_number,
+      files_changed: $files_changed,
+      lines_added: $lines_added,
+      lines_removed: $lines_removed,
+      changed_files: $changed_files
+    },
+    wo_label: $wo_label
+  }' >"$MCP_FILE"
+
+echo ""
+echo "==> GitHub PR: $PR_URL"
+echo "==> Forge MCP payload written to .forge/last-ship-mcp.json"
+echo "    Agent: call create_pull_request then update_work_order (status in_review) using that file."
+cat "$MCP_FILE"

--- a/scripts/install-forge-cursor.sh
+++ b/scripts/install-forge-cursor.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Install Forge Cursor hooks and rules from committed templates (local-only; gitignored).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/scripts/forge-cursor-templates"
+DEST="$ROOT/.cursor"
+
+if [[ ! -d "$SRC" ]]; then
+  echo "Missing templates at $SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST/hooks" "$DEST/rules"
+cp "$SRC/hooks.json" "$DEST/hooks.json"
+cp "$SRC/hooks/"*.sh "$DEST/hooks/"
+chmod +x "$DEST/hooks/"*.sh
+cp "$SRC/rules/"*.mdc "$DEST/rules/"
+
+echo "Installed Forge Cursor hooks and rules to $DEST"
+echo "Run: configure_repo (Forge MCP, ide=cursor) if hooks are missing after clone."


### PR DESCRIPTION
## Summary
- Adds `scripts/forge-wo-ship.sh` to push branch and create/update GitHub PRs
- Commits installable Forge Cursor templates and `install-forge-cursor.sh`
- Documents standing WO completion flow in `docs/FORGE_WO_WORKFLOW.md`

## Test plan
- [ ] Run `./scripts/install-forge-cursor.sh` on a fresh clone
- [ ] Complete a WO: `./scripts/forge-wo-ship.sh WO-XXX <uuid>` then Forge MCP sync


Made with [Cursor](https://cursor.com)