### PR TITLE
fix: fix missing audit_user_id_submit when submitting claims ref36769

### DIFF
--- a/claim/services.py
+++ b/claim/services.py
@@ -248,12 +248,14 @@ class ClaimSubmitService(object):
             )
 
     def __submit_to_rejected(self, claim: Claim):
+        claim.audit_user_id_submit = self.user.id_for_audit
         claim.status = Claim.STATUS_REJECTED
         claim.save()
         return claim
 
     def __submit_to_checked(self, claim: Claim):
         claim.approved = approved_amount(claim)
+        claim.audit_user_id_submit = self.user.id_for_audit
         claim.status = Claim.STATUS_CHECKED
         from core.utils import TimeUtils
 


### PR DESCRIPTION
We've noticed that the `audit_user_id_submit` field is no longer populated when a user submits a claim. After investigation, we found that the code responsible for setting this value was inadvertently dropped during a migration some time ago. Here is the pull request that fixes the issue.

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="883" height="101" alt="Screenshot 2026-06-05 at 12 54 41 PM" src="https://github.com/user-attachments/assets/d8bd38bc-5486-4df0-9654-12e2456a556a" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
