### PR TITLE
refactor(claim): build claim item and service helpers from factories - OP-3114

### DIFF
--- a/claim/test_factories.py
+++ b/claim/test_factories.py
@@ -1,0 +1,26 @@
+import factory
+
+from claim.models import ClaimItem, ClaimService
+
+
+class ClaimItemFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ClaimItem
+
+    qty_provided = 7
+    price_asked = 11
+    status = 1
+    availability = True
+    validity_from = "2019-06-01"
+    audit_user_id = -1
+
+
+class ClaimServiceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ClaimService
+
+    qty_provided = 7
+    price_asked = 11
+    status = 1
+    validity_from = "2019-06-01"
+    audit_user_id = -1

--- a/claim/test_helpers.py
+++ b/claim/test_helpers.py
@@ -3,6 +3,7 @@ from core.models.user import ClaimAdmin
 from claim.validations import get_claim_category
 from claim.utils import approved_amount
 from claim.services import claim_create, update_sum_claims
+from claim.test_factories import ClaimItemFactory, ClaimServiceFactory
 from medical.test_helpers import (
     get_item_of_type,
     get_service_of_category,
@@ -106,16 +107,10 @@ def create_test_claimitem(
         custom_props["item"] = item
 
     custom_props_item = {k: v for k, v in custom_props.items() if hasattr(ClaimItem, k)}
-    item = ClaimItem.objects.create(
+    item = ClaimItemFactory(
         **{
             "claim": claim,
-            "qty_provided": 7,
-            "price_asked": 11,
-            "status": 1,
-            "availability": True,
-            "validity_from": "2019-06-01",
             "validity_to": None if valid else "2019-06-01",
-            "audit_user_id": -1,
             **custom_props_item,
         }
     )
@@ -151,15 +146,10 @@ def create_test_claimservice(
     custom_props_service = {
         k: v for k, v in custom_props.items() if hasattr(ClaimService, k)
     }
-    service = ClaimService.objects.create(
+    service = ClaimServiceFactory(
         **{
             "claim": claim,
-            "qty_provided": 7,
-            "price_asked": 11,
-            "status": 1,
-            "validity_from": "2019-06-01",
             "validity_to": None if valid else "2019-06-01",
-            "audit_user_id": -1,
             **custom_props_service,
         }
     )


### PR DESCRIPTION
Adds `claim/test_factories.py` with `ClaimItemFactory` and `ClaimServiceFactory`, and moves the field defaults out of `create_test_claimitem` and `create_test_claimservice`.

**No call site changes.** `create_test_claimservice` has 50 call sites and `create_test_claimitem` 18; neither is touched.

This is the smallest change of the OP-3114 series and the scope is limited on purpose:

- `create_test_claim` is left alone. It does not touch the ORM at all — it calls `claim_create()`, which owns validation and sub-object handling. A `Claim.objects.create` factory would bypass that, so the package's main model gets no factory.
- `create_test_claim_admin` is left alone. `ClaimAdmin` belongs to `core.models.user`, so its factory belongs in `core`, and moving it there would couple this PR to the core one.
- `create_test_claim_context` is orchestration across seven packages with no `objects.create` of its own.

**Depends on openimis/openimis-be_py#388**, which adds `factory_boy` to `requirements.txt`. Please do not merge this before that one — without it CI here fails on `ModuleNotFoundError: No module named 'factory'`. This is one of seven sibling PRs opened after #388; they are independent of each other and of merge order among themselves.

Tests: `claim claim_sampling policy` — 70 tests, passing, identical to the `develop` baseline.

Unrelated, spotted while running the wider suite and left untouched: `claim_batch/tests/test_graphql.py:132` passes `claim1.health_facility_id` to `add_service_to_hf_pricelist`, which does `hf.services_pricelist` on it. The `AttributeError` in `setUpClass` cascades into 84 `connection already closed` errors across `api_fhir_r4` and `tools`, hiding their real results. Happy to open a separate issue.
